### PR TITLE
Removed deprecated package pimcore/core-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
   ],
   "require": {
     "php": ">=7.2",
-    "pimcore/core-version": ">=5.6.0",
     "pimcore/pimcore": ">=5.6.0",
     "tinify/tinify": "~1.5.2"
   },


### PR DESCRIPTION
Hi!
Looks as composer requirements contain 2 packages pimcore/core-version and pimcore/pimcore.
First is not supported anymore and I suggest to remove that from composer.json.

Thnx! 